### PR TITLE
Fix typo 'deafult' in comments

### DIFF
--- a/latex.py
+++ b/latex.py
@@ -29,7 +29,7 @@ def _create_latex(latex, filename='latexfile', folder='LaTeX', pdf_viewer=None):
         f.write(latex)
 
     # Compiles the LaTeX file, then deletes the 'Temp' folder, recreates it with all the new files.
-    # If pdf_viewer is set to None, it uses the deafult one.
+    # If pdf_viewer is set to None, it uses the default one.
     os.system(f'pdflatex -interaction=batchmode {folder}/{filename}.tex')
     os.system('rm ' + '-r ' + folder + '/Temp')
     os.system(f'mkdir {folder}/Temp')

--- a/lattice_paths.py
+++ b/lattice_paths.py
@@ -195,7 +195,7 @@ def _lattice_paths(width, height=None, shift=None, labelled=True, labels=None, d
         # If no value is specified, the grid is assumed to be a square.
         height = width
 
-    # Sets the deafult set of labels to [n].
+    # Sets the default set of labels to [n].
     if labels is None:
         labels = tuple([0] + [1]*(height))
 
@@ -315,7 +315,7 @@ class LatticePath(ClonableIntArray):
         # Returns all the possible labellings of the path, provided that it has no labels and no decorations.
         # It is possible to specify which labels to use, composition[i] being the number of i's appearing.
 
-        # The deafult set of labels is [n].
+        # The default set of labels is [n].
         if composition is None:
             composition = [0] + [1]*self.height
 


### PR DESCRIPTION
## Summary
- correct the spelling of *default* in lattice_paths and latex

## Testing
- `python -m py_compile latex.py lattice_paths.py`


------
https://chatgpt.com/codex/tasks/task_b_687fa87e81ac832d9cbd3d5c12f3c11f