### PR TITLE
Fix _generate_lattice_paths base case for zero width

### DIFF
--- a/lattice_paths.py
+++ b/lattice_paths.py
@@ -187,6 +187,9 @@ def _generate_lattice_paths(m, n, shift=None, rises=None, falls=None, valleys=No
                         _flag=_flag,
                         _falls_flag=_falls_flag):
                     yield [1] + p
+    else:
+        if shift is None or _flag is True:
+            yield [1]*n
 
 
 def _lattice_paths(width, height=None, shift=None, labelled=True, labels=None, decorated_rises=0, decorated_falls=0, decorated_valleys=0):


### PR DESCRIPTION
## Summary
- handle zero-width case in `_generate_lattice_paths`

## Testing
- `python -m py_compile lattice_paths.py`
- `python -m py_compile *.py`


------
https://chatgpt.com/codex/tasks/task_b_687fa9879d54832db9501e708080356b